### PR TITLE
impl Default and Deref for Ustr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,12 @@ impl From<String> for Ustr {
     }
 }
 
+impl Default for Ustr {
+    fn default() -> Self {
+        Ustr::from("")
+    }
+}
+
 impl fmt::Display for Ustr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_str())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,13 @@ impl Default for Ustr {
     }
 }
 
+impl std::ops::Deref for Ustr {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
 impl fmt::Display for Ustr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_str())


### PR DESCRIPTION
String::default() is an empty string, so this impl does the same.

Deref is also implemented by String and other string interners e.g. string-cache.

Obviously both are pretty convenient, and help Ustr act as a drop-in replacement better.