### PR TITLE
Miri: also check for leaks

### DIFF
--- a/miri.sh
+++ b/miri.sh
@@ -13,4 +13,4 @@ rustup component add miri
 cargo miri setup
 
 export RUST_TEST_THREADS=1
-cargo miri test -- -Zmiri-ignore-leaks
+cargo miri test


### PR DESCRIPTION
With https://github.com/rust-lang/miri/issues/940 fixed, there should not be a reason any more to ignore memory leaks.