### PR TITLE
- Added function existing_ustr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ustr"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Anders Langlands <anderslanglands@gmail.com>"]
 edition = "2018"
 license = "BSD-2-Clause-Patent"

--- a/src/bumpalloc.rs
+++ b/src/bumpalloc.rs
@@ -18,6 +18,7 @@ impl LeakyBumpAlloc {
     pub fn new(capacity: usize, alignment: usize) -> LeakyBumpAlloc {
         let layout = Layout::from_size_align(capacity, alignment).unwrap();
         let start = unsafe { System.alloc(layout) };
+        #[allow(clippy::ptr_offset_with_cast)]
         let end = unsafe { start.offset(layout.size() as isize) };
         let ptr = end;
         LeakyBumpAlloc {

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -27,6 +27,7 @@ impl Serialize for Bins {
 pub struct BinsVisitor {}
 
 impl BinsVisitor {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         BinsVisitor {}
     }
@@ -64,6 +65,7 @@ impl<'de> Deserialize<'de> for DeserializedCache {
 
 pub struct UstrVisitor {}
 impl UstrVisitor {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         UstrVisitor {}
     }


### PR DESCRIPTION
Hello,

I'm proposing the addition of a `existing_ustr` with the following signature: `fn existing_ustr(s: &ustr) -> Option<Ustr>`.

The idea behind this is to allow the creation of a ustr only when that ustr already exists. This is particularly useful when Ustr are being created using untrusted user input (say from a web server or api). In that case, by providing different values at each call we consume more and more memory eventually running out (DoS).

The principal is the same as `String.to_existing_atom/1` in Elixir.

I've added a unit test for the function as well as some compiler directives to silence warnings.