### PR TITLE
chore: bump parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ spin = {version = "0.7.1", optional = true}
 fasthash = {version = "0.4.0", optional = true}
 byteorder = "1.3.2"
 serde = {version="1.0", optional = true}
-parking_lot = {version = "^0.11", optional = true}
+parking_lot = {version = "0.12.1", optional = true}
 ahash = {version = "^0.7"}
 
 [dev-dependencies]


### PR DESCRIPTION
1. Fixed #22
2. Bump `parking_lot` version. 