### PR TITLE
Deps, clippy, Rust 2021, features cleanup, previous PR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,23 +12,23 @@ keywords = ["string", "interning", "FFI"]
 categories = ["caching", "data-structures"]
 
 [badges]
-travis-ci = {repository = "anderslanglands/ustr", branch="master"}
+travis-ci = { repository = "anderslanglands/ustr", branch = "master" }
 
 [dependencies]
-lazy_static = "1.4.0"
+ahash = "0.8.3"
 byteorder = "1.4.3"
-serde = {version="1.0", optional = true}
+lazy_static = "1.4.0"
 parking_lot = "0.12.1"
-ahash = {version = "0.8.3", features = ["compile-time-rng"]}
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.4.0"
-crossbeam-utils = "0.8.1"
 crossbeam-channel = "0.5.0"
-string-interner = "0.13.0"
-string_cache = "0.8.1"
+crossbeam-utils = "0.8.1"
 libc = "0.2.62"
 serde_json = "1.0"
+string-interner = "0.13.0"
+string_cache = "0.8.1"
 
 [[bench]]
 name = "creation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ustr"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Anders Langlands <anderslanglands@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "BSD-2-Clause-Patent"
 description = "Fast, FFI-friendly string interning."
 documentation = "https://docs.rs/ustr"
@@ -16,18 +16,16 @@ travis-ci = {repository = "anderslanglands/ustr", branch="master"}
 
 [dependencies]
 lazy_static = "1.4.0"
-spin = {version = "0.7.1", optional = true}
-fasthash = {version = "0.4.0", optional = true}
-byteorder = "1.3.2"
+byteorder = "1.4.3"
 serde = {version="1.0", optional = true}
-parking_lot = {version = "0.12.1", optional = true}
-ahash = {version = "^0.7"}
+parking_lot = "0.12.1"
+ahash = {version = "0.8.3", features = ["compile-time-rng"]}
 
 [dev-dependencies]
-criterion = "0.3.4"
+criterion = "0.4.0"
 crossbeam-utils = "0.8.1"
 crossbeam-channel = "0.5.0"
-string-interner = "0.12.2"
+string-interner = "0.13.0"
 string_cache = "0.8.1"
 libc = "0.2.62"
 serde_json = "1.0"
@@ -35,10 +33,3 @@ serde_json = "1.0"
 [[bench]]
 name = "creation"
 harness = false
-
-[features]
-default = ["parkinglot"]
-serialization= ["serde"]
-spinlock = ["spin"]
-parkinglot = ["parking_lot"]
-hashcity = ["fasthash"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Ustr
-Fast, FFI-friendly string interning. 
+# `ustr`
+
+Fast, FFI-friendly string interning.
 
 | | | |
 |-|-|-|
@@ -12,30 +13,41 @@ Fast, FFI-friendly string interning.
 [Docs Badge]: https://img.shields.io/docsrs/ustr?style=for-the-badge
 [docs.rs]:https://docs.rs/ustr
 
-A `Ustr` (**U**nique **str**) is a lightweight handle representing a static, immutable entry in a global string cache, allowing for: 
-* Extremely fast string assignment and comparisons 
-* Efficient storage. Only one copy of the string is held in memory, and getting access to it is just a pointer indirection.
-* Fast hashing - the precomputed hash is stored with the string
-* Fast FFI - the string is stored with a terminating null byte so can be passed to C directly without doing the CString dance.
+A `Ustr` (**U**nique **str**) is a lightweight handle representing a static,
+immutable entry in a global string cache, allowing for:
 
-The downside is no strings are ever freed, so if you're creating lots and lots of strings, you might run out of memory. On the other hand, *War and Peace*
-is only 3MB, so it's probably fine. 
+* Extremely fast string assignment and comparisons.
 
-This crate is based on [OpenImageIO's ustring](https://github.com/OpenImageIO/oiio/blob/master/src/include/OpenImageIO/ustring.h) but it is NOT binary-compatible (yet). The underlying hash map implementation is directy ported from OIIO.
+* Efficient storage. Only one copy of the string is held in memory, and
+  getting access to it is just a pointer indirection.
 
-# Usage
+* Fast hashing ‒ the precomputed hash is stored with the string.
+
+* Fast FFI ‒ the string is stored with a terminating null byte so can be
+  passed to C directly without doing the `CString` dance.
+
+The downside is no strings are ever freed, so if you're creating lots and lots
+of strings, you might run out of memory. On the other hand, *War and Peace* is
+only 3MB, so it's probably fine.
+
+This crate is based on [OpenImageIO's](https://openimageio.readthedocs.io/en/v2.4.10.0/)
+(OIIO) [`ustring`](https://github.com/OpenImageIO/oiio/blob/master/src/include/OpenImageIO/ustring.h)
+but it is *not* binary-compatible (yet). The underlying hash map implementation
+is directy ported from OIIO.
+
+## Usage
 
 ```rust
 use ustr::{Ustr, ustr};
 
-// Creation is quick and easy using either `Ustr::from` or the `ustr` short 
+// Creation is quick and easy using either `Ustr::from` or the `ustr` short
 // function and only one copy of any string is stored
 let h1 = Ustr::from("hello");
 let h2 = ustr("hello");
 
 // Comparisons and copies are extremely cheap
 let h3 = h1;
-assert_eq!(h2, h3); 
+assert_eq!(h2, h3);
 
 // You can pass straight to FFI
 let len = unsafe {
@@ -54,21 +66,25 @@ map.insert(u1, 17);
 assert_eq!(*map.get(&u1).unwrap(), 17);
 ```
 
-By enabling the `"serialize"` feature you can serialize individual `Ustr`s or the whole cache with serde. 
+By enabling the `"serialize"` feature you can serialize individual `Ustr`s or
+the whole cache with serde.
 
-```rust 
+```rust
 use ustr::{Ustr, ustr};
+
 let u_ser = ustr("serialization is fun!");
 let json = serde_json::to_string(&u_ser).unwrap();
 let u_de : Ustr = serde_json::from_str(&json).unwrap();
+
 assert_eq!(u_ser, u_de);
 ```
 
-Since the cache is global, use the `ustr::DeserializedCache` dummy object to drive the deserialization.
+Since the cache is global, use the `ustr::DeserializedCache` dummy object to
+drive the deserialization.
 
 ```rust
 ustr("Send me to JSON and back");
-let json = serde_json::to_string(ustr::get_cache()).unwrap();
+let json = serde_json::to_string(ustr::cache()).unwrap();
 
 // ... some time later ...
 let _: ustr::DeserializedCache = serde_json::from_str(&json).unwrap();
@@ -77,145 +93,300 @@ assert_eq!(ustr::string_cache_iter().collect::<Vec<_>>(), vec!["Send me to JSON 
 
 ```
 
-# Calling from C/C++
-If you are writing a library that uses ustr and want users to be able to create `Ustr`s to pass to your API from C, add `ustr_extern.rs` to your crate and use `include/ustr.h` or `include/ustr.hpp` for function declarations.
+## Calling from C/C++
 
-# Changelog
-## Changes since 0.8
-### Add `existing_ustr` function (contributed by macprog-guy)
-The idea behind this is to allow the creation of a ustr only when that ustr already exists. This is particularly useful when Ustr are being created using untrusted user input (say from a web server or api). In that case, by providing different values at each call we consume more and more memory eventually running out (DoS).
+If you are writing a library that uses ustr and want users to be able to create
+`Ustr`s to pass to your API from C, add `ustr_extern.rs` to your crate and use
+`include/ustr.h` or `include/ustr.hpp` for function declarations.
 
-### Add implementation for `Ord` (contributed by zigazeljko)
+## Changelog
 
-### Inlined a bunch of simple functions (contributed by g-plane)
+### Changes since 0.9
 
-### Fixed tests to lock rather than relying on `RUST_TEST_THREADS=1` (contributed by kornelski)
+* Fixed and [issue](https://github.com/anderslanglands/ustr/issues/33) that
+  would stop `Ustr` from working on `wasm32-unknown-unknown` (contributed by bouk)
 
-### Fixed tests to handle serialization feature  properly when enabled (contributed by kornelski)
+* `Ustr::get_cache()` was [renamed](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter)
+  to `cache()`
 
-### Added a check for a potential allocation failure in the allocator (contributed by kornelski)
+* All dependencies were bumped to latest versions
 
-### Added `FromStr` impl (contributed by martinmr)
+* All features were removed (there are good better defaults) except for
+  `serialization`
 
+* The `serialization` feature was [renamed](https://github.com/rust-lang/api-guidelines/discussions/180)
+  to `serde`
 
-### Add rustfmt.toml to repo
+* `ustr` now uses Rust 2021
 
-## Changes since 0.7
-### Update dependencies
-The versions of `parking_lot` and `ahash` have been updated
+### Changes since 0.8
 
-### Space optimization with NonNull
-The internal pointer is now a NonNull to take advanatge of layout optimizations in Option etc.
+* Add `existing_ustr` function (contributed by macprog-guy)
 
-### Add `as_cstr()` method
-Added `as_cstr(&self) -> std::ffi::CStr` to make it easier to interface with APIs that rely on CStr
+  The idea behind this is to allow the creation of a `Ustr` only when that
+  `Ustr` already exists. This is particularly useful when `Ustr`s are being
+  created using untrusted user input (say from a web server or API). In that
+  case, by providing different values at each call we consume more and more
+  memory eventually running out (DoS).
 
+* Add implementation for `Ord` (contributed by zigazeljko)
 
-## Changes since 0.6
-### Derive Ord for Ustr
-So now you can sort a Vec of Ustr's lexicographically.
+* Inlined a bunch of simple functions (contributed by g-plane)
 
-## Changes since 0.5
-### Added From<Ustr> for &str
-This impl makes it easier to pass a Ustr to methods expecting an Into<&str>
+* Fixed tests to lock rather than relying on `RUST_TEST_THREADS=1` (contributed
+  by kornelski)
 
-## Changes since 0.4
-### 32-bit support added
-Removed the restriction to 64-bit systems and fixed a bug relating to pointer maths. Thanks to agaussman for bringing it up: https://github.com/anderslanglands/ustr/issues/8
-### Miri leak checks re-enabled
-Thanks to RalfJung for pointing out that Miri now ignores "leaks" from statics: https://github.com/anderslanglands/ustr/pull/9
-### PartialOrd is now lexicographic
-Thanks to macprog-guy for the PR implementing PartialOrd by deferring to &str. This will be slower than the previous derived implementation which just did a pointer comparison, but is much less surprising: https://github.com/anderslanglands/ustr/pull/10
-## Changes since 0.3
-### Added Miri to CI tests
-Miri sanity-checks the unsafe parts of the code to guard against some types of UB.
-### Switched to [ahash](https://github.com/tkaitchuck/aHash) as the default hasher
-Ahash is a fast, non-cryptographic pure Rust hasher. Pure Rust is important to be able to run Miri and ahash benchmarks the fastest I could find. The old fasthash/cityhash is available by enabling `--features=hashcity`
-## Changes since 0.2
-### Serde support
-`Ustr` can now be serialized with Serde when enabling `--features=serialization`. The global string cache can also be serialized if you really want to.
-### Switched to parking_lot::Mutex as default synchronization
-Spinlocks have been getting a bad rap recently so the string cache now uses `parking_lot::Mutex` as the default synchronization primitive. `spin::Mutex` is still available behind the `--features=spinlock` feature gate if you really want that extra 5% speed.
-### Cleaned up unsafe
-Did a better job of documenting the invariants for the unsafe blocks and replaced some blind additions with checked_add() and friends to avoid potential (but very unlikely) overflow.
+* Fixed tests to handle serialization feature  properly when enabled
+  (contributed by kornelski)
 
-# Compared to string-cache
-[string-cache](https://github.com/servo/string-cache) provides a global cache that can be created at compile time as well as at run time. Dynamic strings in the cache appear to be reference-counted so will be freed when they are no longer used, while `Ustr`s are never deleted. 
+* Added a check for a potential allocation failure in the allocator
+  (contributed by kornelski)
 
-Creating a `string_cache::DefaultAtom` is much slower than creating a `Ustr`, especially in a multi-threaded context. On the other hand if you can just bake all your `Atom`s into your binary at compile-time this wouldn't be an issue. 
+* Added `FromStr` impl (contributed by martinmr)
 
-# Compared to string-interner
-[string-interner](https://github.com/robbepop/string-interner) gives you individual `Interner` objects to work with rather than a global cache, which could be more flexible. It's faster to create than string-cache but still significantly slower than `Ustr`. 
+* Add `rustfmt.toml` to repo
 
-# Speed
-Ustrs are significantly faster to create than string-interner or string-cache. Creating 100,000 cycled copies of ~20,000 path strings of the form:
-```
+### Changes since 0.7
+
+* Update dependencies
+
+  The versions of `parking_lot` and `ahash` have been updated.
+
+* Space optimization with `NonNull`
+
+  The internal pointer is now a `NonNull` to take advanatge of layout
+  optimizations in `Option` etc.
+
+* Add `as_cstr()` method
+
+  Added `as_cstr(&self) -> std::ffi::CStr` to make it easier to interface with
+  APIs that rely on `CStr`.
+
+### Changes since 0.6
+
+* Derive Ord for Ustr
+
+  So now you can sort a `Vec` of `Ustr`s lexicographically.
+
+### Changes since 0.5
+
+* Added `From<Ustr>` for `&str`
+
+  This `impl` makes it easier to pass a `Ustr` to methods expecting an
+  `Into<&str>`.
+
+### Changes since 0.4
+
+* 32-bit support added
+
+  Removed the restriction to 64-bit systems and fixed a bug relating to pointer
+  maths. Thanks to agaussman for [bringing it up](https://github.com/anderslanglands/ustr/issues/8).
+
+* Miri leak checks re-enabled
+
+  Thanks to RalfJung for pointing out that Miri now ignores ["leaks" from statics](https://github.com/anderslanglands/ustr/pull/9).
+
+* `PartialOrd` is now lexicographic
+*
+  Thanks to macprog-guy for the PR implementing PartialOrd by deferring to
+  `&str`. This will be slower than the previous derived implementation which
+  just did a pointer comparison, but is much [less surprising](https://github.com/anderslanglands/ustr/pull/10).
+
+### Changes since 0.3
+
+* Added Miri to CI tests
+
+  Miri sanity-checks the unsafe parts of the code to guard against some types
+  of UB.
+
+* Switched to [ahash](https://github.com/tkaitchuck/aHash) as the default
+  hasher
+
+  Ahash is a fast, non-cryptographic pure Rust hasher. Pure Rust is important
+  to be able to run Miri and ahash benchmarks the fastest I could find. The old
+  `fasthash`/`cityhash` is available by enabling `--features=hashcity`
+
+### Changes since 0.2
+
+* Serde support
+
+  `Ustr` can now be serialized with Serde when enabling
+  `--features=serialization`. The global string cache can also be serialized if
+  you really want to.
+
+* Switched to `parking_lot::Mutex` as default synchronization
+
+  Spinlocks have been getting a bad rap recently so the string cache now uses
+  `parking_lot::Mutex` as the default synchronization primitive. `spin::Mutex`
+  is still available behind the `--features=spinlock` feature gate if you
+  really want that extra 5% speed.
+
+* Cleaned up `unsafe`
+
+  Did a better job of documenting the invariants for the unsafe blocks and
+  replaced some blind additions with checked_add() and friends to avoid
+  potential (but very unlikely) overflow.
+
+* Compared to `string-cache`
+
+  [string-cache](https://github.com/servo/string-cache) provides a global cache
+  that can be created at compile time as well as at run time. Dynamic strings
+  in the cache appear to be reference-counted so will be freed when they are no
+  longer used, while `Ustr`s are never deleted.
+
+  Creating a `string_cache::DefaultAtom` is much slower than creating a `Ustr`,
+  especially in a multi-threaded context. On the other hand if you can just
+  bake all your `Atom`s into your binary at compile-time this wouldn't be an
+  issue.
+
+* Compared to `string-interner`
+
+  [string-interner](https://github.com/robbepop/string-interner) gives you
+  individual `Interner` objects to work with rather than a global cache, which
+  could be more flexible. It's faster to create than string-cache but still
+  significantly slower than `Ustr`.
+
+## Speed
+
+`Ustr`s are significantly faster to create than `string-interner` or
+`string-cache`. Creating 100,000 cycled copies of ~20,000 path strings of the
+form:
+
+```text
 /cgi-bin/images/admin
 /modules/templates/cache
 /libraries/themes/wp-includes
-...etc.
+... etc.
 ```
 
 ![raft bench](ustring_bench_raft.png)
 
-## Synchronization primitives
-ustr can be compiled using either parking_lot::Mutex (`features=parkinglot`) or spin:Mutex (`features=spinlock`) for syncronization. The default is parking_lot. Spinlocks have gotten bad press lately, but ustr still benches slightly faster using them. Use at your discretion.
+## Why?
 
-![mutex bench](mutex_comparison.png)
-
-# Why?
-It is common in certain types of applications to use strings as identifiers, but not really do any processing with them. To paraphrase from OIIO's ustring documentation...
+It is common in certain types of applications to use strings as identifiers,
+but not really do any processing with them. To paraphrase from OIIO's `ustring`
+documentation:
 
 Compared to standard strings, `Ustr`s have several advantages:
 
-- Each individual `Ustr` is very small -- in fact, we guarantee that a `Ustr` is the same size and memory layout as an ordinary *u8.
-- Storage is frugal, since there is only one allocated copy of each unique character sequence, throughout the lifetime of the program.
-- Assignment from one `Ustr` to another is just copy of the pointer; no allocation, no character copying, no reference counting.
-- Equality testing (do the strings contain the same characters) is a single operation, the comparison of the pointer.
-- Memory allocation only occurs when a new `Ustr` is constructed from raw characters the FIRST time -- subsequent constructions of the same string just finds it in the canonial string set, but doesn't need to allocate new storage.  Destruction of a `Ustr` is trivial, there is no de-allocation because the canonical version stays in the set.  Also, therefore, no user code mistake can lead to memory leaks.
+* Each individual `Ustr` is very small -- in fact, we guarantee that a `Ustr`
+  is the same size and memory layout as an ordinary *u8.
 
-But there are some problems, too.  Canonical strings are never freed from the table.  So in some sense all the strings "leak", but they only leak one copy for each unique string that the program ever comes across. Creating a `Ustr` is slower than `String::from()` on a single thread, and performance will be worse if trying to create many `Ustr`s in tight loops from multiple threads due to lock contention for the global cache.
+* Storage is frugal, since there is only one allocated copy of each unique
+  character sequence, throughout the lifetime of the program.
+
+* Assignment from one `Ustr` to another is just copy of the pointer; no
+  allocation, no character copying, no reference counting.
+
+* Equality testing (do the strings contain the same characters) is a single
+  operation, the comparison of the pointer.
+
+* Memory allocation only occurs when a new `Ustr` is constructed from raw
+  characters the *first* time ‒ subsequent constructions of the same string
+  just finds it in the canonial string set, but doesn't need to allocate new
+  storage.  Destruction of a `Ustr` is trivial, there is no de-allocation
+  because the canonical version stays in the set.  Also, therefore, no user
+  code mistake can lead to memory leaks.
+
+  But there are some problems, too.  Canonical strings are never freed from the
+  table. So in some sense all the strings "leak", but they only leak one copy
+  for each unique string that the program ever comes across. Creating a `Ustr`
+  is slower than `String::from()` on a single thread, and performance will be
+  worse if trying to create many `Ustr`s in tight loops from multiple threads
+  due to lock contention for the global cache.
 
 On the whole, `Ustr`s are a really great string representation
-- if you tend to have (relatively) few unique strings, but many copies of those strings;
-- if you tend to make the same strings over and over again, and if it's relatively rare that a single unique character sequence is used only once in the entire lifetime of the program; - if your most common string operations are assignment and equality testing and you want them to be as fast as possible;
-- if you are doing relatively little character-by-character assembly of strings, string concatenation, or other "string manipulation" (other than equality testing).
+
+* if you tend to have (relatively) few unique strings, but many copies of those
+  strings;
+
+* if you tend to make the same strings over and over again, and if it's
+  relatively rare that a single unique character sequence is used only once in
+  the entire lifetime of the program; ‒ if your most common string operations
+  are assignment and equality testing and you want them to be as fast as
+  possible;
+
+* if you are doing relatively little character-by-character assembly of
+  strings, string concatenation, or other "string manipulation" (other than
+  equality testing).
 
 `Ustr`s are not so hot:
-- if your program tends to have very few copies of each character sequence over the entire lifetime of the program;
-- if your program tends to generate a huge variety of unique strings over its lifetime, each of which is used only a short time and then discarded, never to be needed again;
-- if you don't need to do a lot of string assignment or equality testing, but lots of more complex string manipulation.
+
+* if your program tends to have very few copies of each character sequence over
+  the entire lifetime of the program;
+
+* if your program tends to generate a huge variety of unique strings over its
+  lifetime, each of which is used only a short time and then discarded, never
+  to be needed again;
+
+* if you don't need to do a lot of string assignment or equality testing, but
+  lots of more complex string manipulation.
 
 ## Safety and Compatibility
-This crate contains a significant amount of unsafe but usage has been checked and is well-documented. It is also run through Miri as part of the CI process. 
 
-I use it regularly on 64-bit systems, and it has passed Miri on a 32-bit system as well, bit 32-bit is not checked regularly. If you want to use it on 32-bit, please make sure to run Miri and open and issue if you find any problems.
+This crate contains a significant amount of unsafe but usage has been checked
+and is well-documented. It is also run through Miri as part of the CI process.
+
+I use it regularly on 64-bit systems, and it has passed Miri on a 32-bit system
+as well, bit 32-bit is not checked regularly. If you want to use it on 32-bit,
+please make sure to run Miri and open and issue if you find any problems.
 
 ## Licence
+
 BSD+ License
 
-Copyright ©2019-2020 Anders Langlands
+Copyright © 2019—2020 Anders Langlands
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-Subject to the terms and conditions of this license, each copyright holder and contributor hereby grants to those receiving rights under this license a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except for failure to satisfy the conditions of this license) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer this software, where such license applies only to those patent claims, already acquired or hereafter acquired, licensable by such copyright holder or contributor that are necessarily infringed by:
+Subject to the terms and conditions of this license, each copyright holder and
+contributor hereby grants to those receiving rights under this license a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except for failure to satisfy the conditions of this license) patent license
+to make, have made, use, offer to sell, sell, import, and otherwise transfer
+this software, where such license applies only to those patent claims, already
+acquired or hereafter acquired, licensable by such copyright holder or
+contributor that are necessarily infringed by:
 
-(a) their Contribution(s) (the licensed copyrights of copyright holders and non-copyrightable additions of contributors, in source or binary form) alone; or
+(a) their Contribution(s) (the licensed copyrights of copyright holders and
+non-copyrightable additions of contributors, in source or binary form) alone;
+or
 
-(b) combination of their Contribution(s) with the work of authorship to which such Contribution(s) was added by such copyright holder or contributor, if, at the time the Contribution is added, such addition causes such combination to be necessarily infringed. The patent license shall not apply to any other combinations which include the Contribution.
+(b) combination of their Contribution(s) with the work of authorship to which
+such Contribution(s) was added by such copyright holder or contributor, if, at
+the time the Contribution is added, such addition causes such combination to be
+necessarily infringed. The patent license shall not apply to any other
+combinations which include the Contribution.
 
-Except as expressly stated above, no rights or licenses from any copyright holder or contributor is granted under this license, whether expressly, by implication, estoppel or otherwise.
+Except as expressly stated above, no rights or licenses from any copyright
+holder or contributor is granted under this license, whether expressly, by
+implication, estoppel or otherwise.
 
 DISCLAIMER
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Contains code ported from [OpenImageIO](https://github.com/OpenImageIO/oiio), BSD 3-clause licence.
+Contains code ported from [OpenImageIO](https://github.com/OpenImageIO/oiio),
+BSD 3-clause licence.
 
 Contains a copy of Max Woolf's [Big List of Naughty Strings](https://github.com/minimaxir/big-list-of-naughty-strings), MIT licence.
 
-Contains some strings from [SecLists](https://github.com/danielmiessler/SecLists), MIT licence.
+Contains some strings from
+[SecLists](https://github.com/danielmiessler/SecLists), MIT licence.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 Fast, FFI-friendly string interning.
 
-| | | |
-|-|-|-|
-| [![Build Status]][travis] | [![Latest Version]][crates.io] | [![Docs Badge]][docs.rs] |
+[![Build Status]][travis][![Latest Version]][crates.io][![Docs Badge]][docs.rs] |
 
 [Build Status]: https://img.shields.io/travis/anderslanglands/ustr/master?style=for-the-badge
 [travis]: https://travis-ci.com/anderslanglands/ustr
@@ -111,7 +109,7 @@ If you are writing a library that uses ustr and want users to be able to create
 
 * All dependencies were bumped to latest versions
 
-* All features were removed (there are good better defaults) except for
+* All features were removed (there are good defaults) except for
   `serialization`
 
 * The `serialization` feature was [renamed](https://github.com/rust-lang/api-guidelines/discussions/180)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Fast, FFI-friendly string interning.
 
-[![Build Status]][travis][![Latest Version]][crates.io][![Docs Badge]][docs.rs] |
+[![Build Status]][travis] [![Latest Version]][crates.io] [![Docs Badge]][docs.rs]
 
 [Build Status]: https://img.shields.io/travis/anderslanglands/ustr/master?style=for-the-badge
 [travis]: https://travis-ci.com/anderslanglands/ustr

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -3,24 +3,18 @@ use byteorder::{ByteOrder, NativeEndian};
 use std::collections::{HashMap, HashSet};
 use std::hash::{BuildHasherDefault, Hasher};
 
-/// A standard `HashMap` using `Ustr` as the key type with a custom `Hasher` that
-/// just uses the precomputed hash for speed instead of calculating it
+/// A standard `HashMap` using `Ustr` as the key type with a custom `Hasher`
+/// that just uses the precomputed hash for speed instead of calculating it
 pub type UstrMap<V> = HashMap<Ustr, V, BuildHasherDefault<IdentityHasher>>;
-/// A standard `HashSet` using `Ustr` as the key type with a custom `Hasher` that
-/// just uses the precomputed hash for speed instead of calculating it
+/// A standard `HashSet` using `Ustr` as the key type with a custom `Hasher`
+/// that just uses the precomputed hash for speed instead of calculating it
 pub type UstrSet = HashSet<Ustr, BuildHasherDefault<IdentityHasher>>;
 
 /// The worst hasher in the world - the identity hasher.
 #[doc(hidden)]
+#[derive(Default)]
 pub struct IdentityHasher {
     hash: u64,
-}
-
-impl Default for IdentityHasher {
-    #[inline]
-    fn default() -> IdentityHasher {
-        IdentityHasher { hash: 0 }
-    }
 }
 
 impl Hasher for IdentityHasher {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,23 @@
-//! Fast, FFI-friendly string interning. A `Ustr` (**U**nique **Str**) is a lightweight handle representing a static, immutable entry in a global string cache, allowing for:
-//! * Extremely fast string assignment and comparisons - it's just a pointer comparison.
-//! * Efficient storage -  only one copy of the string is held in memory, and getting access to it is just a pointer indirection.
-//! * Fast hashing - the precomputed hash is stored with the string
-//! * Fast FFI - the string is stored with a terminating null byte so can be passed to C directly without doing the CString dance.
+//! Fast, FFI-friendly string interning. A [`Ustr`] (**U**nique **Str**) is a
+//! lightweight handle representing a static, immutable entry in a global string
+//! cache, allowing for:
+//! * Extremely fast string assignment and comparisons -- it's just a pointer
+//!   comparison.
+//! * Efficient storage -- only one copy of the string is held in memory, and
+//!   getting access to it is just a pointer indirection.
+//! * Fast hashing -- the precomputed hash is stored with the string
+//! * Fast FFI -- the string is stored with a terminating null byte so can be
+//!   passed to C directly without doing the CString dance.
 //!
-//! The downside is no strings are ever freed, so if you're creating lots and lots of strings, you might run out of memory. On the other hand, War and Peace
-//! is only 3MB, so it's probably fine.
+//! The downside is no strings are ever freed, so if you're creating lots and
+//! lots of strings, you might run out of memory. On the other hand, War and
+//! Peace is only 3MB, so it's probably fine.
 //!
 //! This crate is based on [OpenImageIO's ustring](https://github.com/OpenImageIO/oiio/blob/master/src/include/OpenImageIO/ustring.h) but it is NOT binary-compatible (yet). The underlying hash map implementation is directy ported from OIIO.
 //!
 //! # Usage
 //!
-//! ```rust
+//! ```
 //! use ustr::{Ustr, ustr, ustr as u};
 //!
 //! # unsafe { ustr::_clear_cache() };
@@ -45,10 +51,10 @@
 //! assert_eq!(*map.get(&u1).unwrap(), 17);
 //! ```
 //!
+//! By enabling the `"serialize"` feature you can serialize individual `Ustr`s
+//! or the whole cache with serde.
 //!
-//! By enabling the `"serialize"` feature you can serialize individual `Ustr`s or the whole cache with serde.
-//!
-//! ```rust
+//! ```
 //! # #[cfg(feature = "serialization")] {
 //! use ustr::{Ustr, ustr};
 //! let u_ser = ustr("serialization is fun!");
@@ -58,13 +64,14 @@
 //! # }
 //! ```
 //!
-//! Since the cache is global, use the `ustr::DeserializedCache` dummy object to drive the deserialization.
+//! Since the cache is global, use the `ustr::DeserializedCache` dummy object to
+//! drive the deserialization.
 //!
-//! ```rust
+//! ```
 //! # #[cfg(feature = "serialization")] {
 //! use ustr::{Ustr, ustr};
 //! ustr("Send me to JSON and back");
-//! let json = serde_json::to_string(ustr::get_cache()).unwrap();
+//! let json = serde_json::to_string(ustr::cache()).unwrap();
 //!
 //! // ... some time later ...
 //! let _: ustr::DeserializedCache = serde_json::from_str(&json).unwrap();
@@ -73,70 +80,65 @@
 //! # }
 //! ```
 //!
-//!
 //! ## Why?
+//!
 //! It is common in certain types of applications to use strings as identifiers,
 //! but not really do any processing with them.
-//! To paraphrase from OIIO's Ustring documentation -
-//! Compared to standard strings, Ustrs have several advantages:
+//! To paraphrase from OIIO's `Ustring` documentation -- compared to standard
+//! strings, `Ustr`s have several advantages:
 //!
-//!   - Each individual Ustr is very small -- in fact, we guarantee that
-//!     a Ustr is the same size and memory layout as an ordinary *u8.
-//!   - Storage is frugal, since there is only one allocated copy of each
-//!     unique character sequence, throughout the lifetime of the program.
-//!   - Assignment from one Ustr to another is just copy of the pointer;
-//!     no allocation, no character copying, no reference counting.
-//!   - Equality testing (do the strings contain the same characters) is
-//!     a single operation, the comparison of the pointer.
-//!   - Memory allocation only occurs when a new Ustr is constructed from
-//!     raw characters the FIRST time -- subsequent constructions of the
-//!     same string just finds it in the canonial string set, but doesn't
-//!     need to allocate new storage.  Destruction of a Ustr is trivial,
-//!     there is no de-allocation because the canonical version stays in
-//!     the set.  Also, therefore, no user code mistake can lead to
-//!     memory leaks.
+//!   - Each individual `Ustr` is very small -- in fact, we guarantee that a
+//!     `Ustr` is the same size and memory layout as an ordinary `*u8`.
+//!   - Storage is frugal, since there is only one allocated copy of each unique
+//!     character sequence, throughout the lifetime of the program.
+//!   - Assignment from one `Ustr` to another is just copy of the pointer; no
+//!     allocation, no character copying, no reference counting.
+//!   - Equality testing (do the strings contain the same characters) is a
+//!     single operation, the comparison of the pointer.
+//!   - Memory allocation only occurs when a new `Ustr` is constructed from raw
+//!     characters the FIRST time -- subsequent constructions of the same string
+//!     just finds it in the canonial string set, but doesn't need to allocate
+//!     new storage.  Destruction of a `Ustr` is trivial, there is no
+//!     de-allocation because the canonical version stays in the set.  Also,
+//!     therefore, no user code mistake can lead to memory leaks.
 //!
 //! But there are some problems, too.  Canonical strings are never freed
 //! from the table.  So in some sense all the strings "leak", but they
 //! only leak one copy for each unique string that the program ever comes
 //! across.
 //!
-//! On the whole, Ustrs are a really great string representation
-//!   - if you tend to have (relatively) few unique strings, but many
-//!     copies of those strings;
-//!   - if the creation of strings from raw characters is relatively
-//!     rare compared to copying or comparing to existing strings;
-//!   - if you tend to make the same strings over and over again, and
-//!     if it's relatively rare that a single unique character sequence
-//!     is used only once in the entire lifetime of the program;
+//! On the whole, `Ustr`s are a really great string representation
+//!   - if you tend to have (relatively) few unique strings, but many copies of
+//!     those strings;
+//!   - if the creation of strings from raw characters is relatively rare
+//!     compared to copying or comparing to existing strings;
+//!   - if you tend to make the same strings over and over again, and if it's
+//!     relatively rare that a single unique character sequence is used only
+//!     once in the entire lifetime of the program;
 //!   - if your most common string operations are assignment and equality
 //!     testing and you want them to be as fast as possible;
-//!   - if you are doing relatively little character-by-character assembly
-//!     of strings, string concatenation, or other "string manipulation"
-//!     (other than equality testing).
+//!   - if you are doing relatively little character-by-character assembly of
+//!     strings, string concatenation, or other "string manipulation" (other
+//!     than equality testing).
 //!
-//! Ustrs are not so hot
-//!   - if your program tends to have very few copies of each character
-//!     sequence over the entire lifetime of the program;
-//!   - if your program tends to generate a huge variety of unique
-//!     strings over its lifetime, each of which is used only a short
-//!     time and then discarded, never to be needed again;
-//!   - if you don't need to do a lot of string assignment or equality
-//!     testing, but lots of more complex string manipulation.
+//! `Ustr`s are not so hot
+//!   - if your program tends to have very few copies of each character sequence
+//!     over the entire lifetime of the program;
+//!   - if your program tends to generate a huge variety of unique strings over
+//!     its lifetime, each of which is used only a short time and then
+//!     discarded, never to be needed again;
+//!   - if you don't need to do a lot of string assignment or equality testing,
+//!     but lots of more complex string manipulation.
 //!
 //! ## Safety and Compatibility
-//! This crate contains a significant amount of unsafe but usage has been checked
-//! and is well-documented. It is also run through Miri as part of the CI process.
-//! I use it regularly on 64-bit systems, and it has passed Miri on a 32-bit
-//! system as well, bit 32-bit is not checked regularly. If you want to use it
-//! on 32-bit, please make sure to run Miri and open and issue if you find any
-//! problems.
-
-#[cfg(not(feature = "spinlock"))]
+//!
+//! This crate contains a significant amount of unsafe but usage has been
+//! checked and is well-documented. It is also run through Miri as part of the
+//! CI process. I use it regularly on 64-bit systems, and it has passed Miri on
+//! a 32-bit system as well, bit 32-bit is not checked regularly. If you want to
+//! use it on 32-bit, please make sure to run Miri and open and issue if you
+//! find any problems.
 use parking_lot::Mutex;
-#[cfg(feature = "spinlock")]
-use spin::Mutex;
-
 use std::fmt;
 use std::str::FromStr;
 
@@ -160,20 +162,6 @@ use std::ptr::NonNull;
 /// To use, create one using `Ustr::from` or the `ustr` function. You can freely
 /// copy, destroy or send Ustrs to other threads: the underlying string is
 /// always valid in memory (and is never destroyed).
-#[cfg_attr(
-    feature = "spinlock",
-    deprecated(
-        since = "0.9.0",
-        note = "spinlock was experimental and has now been deprecated for removal in 1.0, where parking_lot's Mutex will be the only synchronization primitive. Please do not use the 'spinlock' feature"
-    )
-)]
-#[cfg_attr(
-    feature = "fasthash",
-    deprecated(
-        since = "0.9.0",
-        note = "fasthash support is deprecated and will be removed in 1.0 as ahash in better in all situations."
-    )
-)]
 #[derive(Copy, Clone, PartialEq)]
 #[repr(transparent)]
 pub struct Ustr {
@@ -212,11 +200,8 @@ impl Ustr {
     /// assert_eq!(ustr::num_entries(), 1);
     /// ```
     pub fn from(string: &str) -> Ustr {
-        #[cfg(feature = "hashcity")]
-        let hash = fasthash::city::hash64(string.as_bytes());
-        #[cfg(not(feature = "hashcity"))]
         let hash = {
-            let mut hasher = ahash::AHasher::new_with_keys(123, 456);
+            let mut hasher = ahash::AHasher::default();
             hasher.write(string.as_bytes());
             hasher.finish()
         };
@@ -230,11 +215,8 @@ impl Ustr {
     }
 
     pub fn from_existing(string: &str) -> Option<Ustr> {
-        #[cfg(feature = "hashcity")]
-        let hash = fasthash::city::hash64(string.as_bytes());
-        #[cfg(not(feature = "hashcity"))]
         let hash = {
-            let mut hasher = ahash::AHasher::new_with_keys(123, 456);
+            let mut hasher = ahash::AHasher::default();
             hasher.write(string.as_bytes());
             hasher.finish()
         };
@@ -427,7 +409,7 @@ impl fmt::Debug for Ustr {
 
 // Just feed the precomputed hash into the Hasher. Note that this will of course
 // be terrible unless the Hasher in question is expecting a precomputed hash.
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for Ustr {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.precomputed_hash().hash(state);
@@ -449,7 +431,8 @@ pub unsafe fn _clear_cache() {
     }
 }
 
-/// Returns the total amount of memory allocated and in use by the cache in bytes
+/// Returns the total amount of memory allocated and in use by the cache in
+/// bytes
 pub fn total_allocated() -> usize {
     STRING_CACHE
         .0
@@ -490,7 +473,8 @@ pub fn ustr(s: &str) -> Ustr {
     Ustr::from(s)
 }
 
-/// Create a new Ustr from the given &str but only if it already exists in the string cache.
+/// Create a new Ustr from the given &str but only if it already exists in the
+/// string cache.
 ///
 /// ```
 /// use ustr::{ustr, existing_ustr};
@@ -519,8 +503,8 @@ pub fn existing_ustr(s: &str) -> Option<Ustr> {
 /// ustr("Send me to JSON and back");
 /// let json = serde_json::to_string(ustr::get_cache()).unwrap();
 /// # }
-pub fn get_cache() -> &'static Bins {
-    &*STRING_CACHE
+pub fn cache() -> &'static Bins {
+    &STRING_CACHE
 }
 
 /// Returns the number of unique strings in the cache
@@ -560,8 +544,8 @@ pub fn num_entries_per_bin() -> Vec<usize> {
 
 /// Return an iterator over the entire string cache.
 ///
-/// If another thread is adding strings concurrently to this call then they might
-/// not show up in the view of the cache presented by this iterator.
+/// If another thread is adding strings concurrently to this call then they
+/// might not show up in the view of the cache presented by this iterator.
 ///
 /// # Safety
 /// This returns an iterator to the state of the cache at the time when
@@ -665,7 +649,8 @@ mod tests {
         // clear the cache first or our results will be wrong
         unsafe { super::_clear_cache() };
 
-        // let path = std::path::Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        // let path =
+        // std::path::Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
         //     .join("data")
         //     .join("blns.txt");
         // let blns = std::fs::read_to_string(path).unwrap();
@@ -718,7 +703,8 @@ mod tests {
         use super::ustr as u;
         use std::sync::Arc;
 
-        // let path = std::path::Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        // let path =
+        // std::path::Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
         //     .join("data")
         //     .join("raft-large-directories.txt");
         // let raft = std::fs::read_to_string(path).unwrap();
@@ -802,7 +788,7 @@ mod tests {
             ss.push(s.to_owned());
         }
 
-        let json = serde_json::to_string(super::get_cache()).unwrap();
+        let json = serde_json::to_string(super::cache()).unwrap();
         unsafe {
             super::_clear_cache();
         }

--- a/src/stringcache.rs
+++ b/src/stringcache.rs
@@ -36,8 +36,9 @@ pub(crate) struct StringCache {
     num_entries: usize,
     mask: usize,
     total_allocated: usize,
-    // padding and aligning to 128 bytes gives up to 20% performance improvement
-    // this actually aligns to 256 bytes because of the Mutex around it
+    // padding and aligning to 128 bytes gives up to 20% performance
+    // improvement this actually aligns to 256 bytes because of the Mutex
+    // around it
     _pad: [u32; 3],
 }
 
@@ -200,9 +201,10 @@ impl StringCache {
         }
 
         // This is safe as long as:
-        // 1) alloc_size is calculated correctly
-        // 2) there is enough space in the allocator (checked in the block above)
-        // 3) The StringCacheEntry layout descibed above holds and the memory
+        // 1. alloc_size is calculated correctly
+        // 2. there is enough space in the allocator (checked in the block
+        //    above)
+        // 3. The StringCacheEntry layout descibed above holds and the memory
         //    returned by allocate() is prooperly aligned.
         unsafe {
             *entry_ptr =


### PR DESCRIPTION
* Includes #34 which fixes #33.

* `Ustr::get_cache()` was [renamed](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter) to `cache()`.

* All dependencies were bumped to latest versions (except `dev-dependencies/string-interner` which is now at `0.13.0` but needs work for updating to `0.14.0`)

* All features were removed (they were marked as deprecated in the source) except for `serialization`.

* The `serialization` feature was [renamed](https://github.com/rust-lang/api-guidelines/discussions/180) to `serde`.

* `ustr` now uses Rust 2021.

* The above was added as to the README's changelog.

* README formatted to 80c/l.

* Clippy was made happy.