### PR TITLE
Fix warnings and errors from Clippy and Miri

### DIFF
--- a/src/bumpalloc.rs
+++ b/src/bumpalloc.rs
@@ -56,7 +56,7 @@ impl LeakyBumpAlloc {
             std::process::abort();
         }
 
-        self.ptr = new_ptr as *mut u8;
+        self.ptr = self.ptr.sub(ptr - new_ptr);
         self.ptr
     }
 


### PR DESCRIPTION
- Fix Clippy's warnings.
- Fix Miri's integer-to-pointer cast warning and the borrow stack error.
- Fix a panic in `string_cache_iter()` if the string cache is empty, and add a corresponding test.